### PR TITLE
Fixing typo when using DK2 as area (Eastern Denmark)

### DIFF
--- a/custom_components/energidataservice/const.py
+++ b/custom_components/energidataservice/const.py
@@ -77,7 +77,7 @@ _CURRENCY = {
 #   "Region": [_CURRENCY, "Country", "Region description", VAT]
 _REGIONS = {
     "DK1": [_CURRENCY["DKK"], "Denmark", "West of the great belt", 0.25],
-    "DK2": [_CURRENCY["DKK"], "Denmark", "West of the great belt", 0.25],
+    "DK2": [_CURRENCY["DKK"], "Denmark", "East of the great belt", 0.25],
     "FI": [_CURRENCY["EUR"], "Finland", "Finland", 0.24],
     "EE": [_CURRENCY["EUR"], "Estonia", "Estonia", 0.20],
     "LT": [_CURRENCY["EUR"], "Lithuania", "Lithuania", 0.21],

--- a/custom_components/energidataservice/manifest.json
+++ b/custom_components/energidataservice/manifest.json
@@ -12,7 +12,7 @@
     "codeowners": [
         "@MTrab"
     ],
-    "version": "0.1.7",
+    "version": "0.1.9",
     "config_flow": true,
     "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
Fixes #38 