### PR TITLE
Sort connectors list alphabetically

### DIFF
--- a/custom_components/energidataservice/connectors/__init__.py
+++ b/custom_components/energidataservice/connectors/__init__.py
@@ -21,7 +21,7 @@ class Connectors:
         """Initialize connector handler."""
 
         self._connectors = []
-        for module in listdir(f"{dirname(__file__)}"):
+        for module in sorted(listdir(f"{dirname(__file__)}")):
             mod_path = f"{dirname(__file__)}/{module}"
             if isdir(mod_path) and not module.endswith("__pycache__"):
                 Connector = namedtuple("Connector", "module namespace regions")


### PR DESCRIPTION
Fixes #52

Prioritizing can be achived by renaming the connector directories.

Example:
We want to use `Nordpool` as the primary connector, then rename `connectors/nordpool` to `connectors/1-nordpool`