### PR TITLE
Fix-Carnot-data

### DIFF
--- a/custom_components/energidataservice/__init__.py
+++ b/custom_components/energidataservice/__init__.py
@@ -161,6 +161,8 @@ class APIConnector:
         self.today_calculated = False
         self.tomorrow_calculated = False
         self.predictions_calculated = False
+        self.connector_currency = "EUR"
+        self.forecast_currency = "EUR"
         self.listeners = []
 
         self.next_retry_delay = RETRY_MINUTES
@@ -184,6 +186,7 @@ class APIConnector:
             for endpoint in connectors:
                 module = import_module(endpoint.namespace, __name__)
                 api = module.Connector(self._region, self._client, self._tz)
+                self.connector_currency = module.DEFAULT_CURRENCY
                 await api.async_get_spotprices()
                 if api.today:
                     self.today = api.today
@@ -241,6 +244,7 @@ class APIConnector:
                     forecast_endpoint[0].namespace, __name__
                 )
                 carnot = forecast_module.Connector(self._region, self._client, self._tz)
+                self.predictions_currency = forecast_module.DEFAULT_CURRENCY
                 self.predictions = await carnot.async_get_forecast(
                     self._carnot_apikey, self._carnot_user
                 )

--- a/custom_components/energidataservice/connectors/energidataservice/__init__.py
+++ b/custom_components/energidataservice/connectors/energidataservice/__init__.py
@@ -15,7 +15,9 @@ BASE_URL = "https://api.energidataservice.dk/dataset/elspotprices"
 
 SOURCE_NAME = "Energi Data Service"
 
-__all__ = ["REGIONS", "Connector"]
+DEFAULT_CURRENCY = "EUR"
+
+__all__ = ["REGIONS", "Connector", "DEFAULT_CURRENCY"]
 
 
 def prepare_data(indata, date, tz) -> list:  # pylint: disable=invalid-name

--- a/custom_components/energidataservice/connectors/nordpool/__init__.py
+++ b/custom_components/energidataservice/connectors/nordpool/__init__.py
@@ -19,7 +19,9 @@ BASE_URL = (
 
 SOURCE_NAME = "Nord Pool"
 
-__all__ = ["REGIONS", "Connector"]
+DEFAULT_CURRENCY = "EUR"
+
+__all__ = ["REGIONS", "Connector", "DEFAULT_CURRENCY"]
 
 
 def prepare_data(indata, date, tz) -> list:  # pylint: disable=invalid-name
@@ -61,6 +63,7 @@ class Connector:
 
         res = await asyncio.gather(*jobs)
         raw = []
+
         for i in res:
             raw = raw + self._parse_json(i)
 

--- a/custom_components/energidataservice/forecasts/__init__.py
+++ b/custom_components/energidataservice/forecasts/__init__.py
@@ -21,7 +21,7 @@ class Forecast:
         """Initialize forecast handler."""
 
         self._forecasts = []
-        for module in listdir(f"{dirname(__file__)}"):
+        for module in sorted(listdir(f"{dirname(__file__)}")):
             mod_path = f"{dirname(__file__)}/{module}"
             if (
                 isdir(mod_path)

--- a/custom_components/energidataservice/forecasts/carnot/__init__.py
+++ b/custom_components/energidataservice/forecasts/carnot/__init__.py
@@ -32,7 +32,7 @@ def prepare_data(indata, tz) -> list | None:  # pylint: disable=invalid-name
                 .astimezone(local_tz)
             )
             if not tmpdate.day == datetime.now().day:
-                tmp = INTERVAL(dataset["prediction"] / 10, local_tz.normalize(tmpdate))
+                tmp = INTERVAL(dataset["prediction"], local_tz.normalize(tmpdate))
                 reslist.append(tmp)
 
         return reslist


### PR DESCRIPTION
Fixes #105

Also intruduces a breaking change if you have made your own connectors.

ALL connectors need to have a variable named `DEFAULT_CURRENCY` and that should represent which currency the API data is delivered in (see energidataservice or nordpool connectors for examples)