### PR TITLE
Add correct GLN number for Netselskabet Elværk

### DIFF
--- a/custom_components/energidataservice/tariffs/energidataservice/chargeowners.py
+++ b/custom_components/energidataservice/tariffs/energidataservice/chargeowners.py
@@ -86,7 +86,7 @@ CHARGEOWNERS = {
         "note": ["Nettarif C time"],
     },
     "Netselskabet Elværk": {
-        "gln": "5790000610976",
+        "gln": "5790000681075",
         "company": "Netselskabet Elværk A/S - 042",
         "type": ["0NCFF"],
         "note": ["Nettarif C Flex"],


### PR DESCRIPTION
Add correct GLN number for Netselskabet Elværk A/S - 042

Verified data from https://www.energidataservice.dk/tso-electricity/DatahubPricelist up against https://www.elvrk.dk/forside/priser/.