### PR TITLE
Add Radius Elnet tariff "B lav time"

### DIFF
--- a/custom_components/energidataservice/manifest.json
+++ b/custom_components/energidataservice/manifest.json
@@ -1,6 +1,6 @@
 {
     "domain": "energidataservice",
-    "name": "Energi Data Service",
+    "name": "Energi Data Service local",
     "after_dependencies": [
         "http"
     ],

--- a/custom_components/energidataservice/tariffs/energidataservice/chargeowners.py
+++ b/custom_components/energidataservice/tariffs/energidataservice/chargeowners.py
@@ -7,6 +7,12 @@ CHARGEOWNERS = {
         "type": ["DT_C_01"],
         "note": ["Nettarif C time"],
     },
+    "Radius": {
+        "gln": "5790000705689",
+        "company": "Radius Elnet A/S",
+        "type": ["DT_B_02"],
+        "note": ["Nettarif B lav time"],
+    },
     "RAH": {
         "gln": "5790000681327",
         "company": "RAH Net A/S",

--- a/custom_components/energidataservice/tariffs/energidataservice/chargeowners.py
+++ b/custom_components/energidataservice/tariffs/energidataservice/chargeowners.py
@@ -1,13 +1,13 @@
 """Valid Charge Owners for Energi Data Service connector."""
 
 CHARGEOWNERS = {
-    "Radius": {
+    "Radius C": {
         "gln": "5790000705689",
         "company": "Radius Elnet A/S",
         "type": ["DT_C_01"],
         "note": ["Nettarif C time"],
     },
-    "Radius": {
+    "Radius B lav": {
         "gln": "5790000705689",
         "company": "Radius Elnet A/S",
         "type": ["DT_B_02"],

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "Energi Data Service",
+    "name": "Energi Data Service Niko",
     "render_readme": true,
     "homeassistant": "2023.3.0",
     "zip_release": true,


### PR DESCRIPTION
I have added the B Lav Time tariff to the chargeowners.py and renamed "Radius" to "Radius C". When doing this change in my home installation it works great. This is my first online change, so I hope it works.