### PR TITLE
Fix issue #319 new prices does not show until reload or at midnight

### DIFF
--- a/custom_components/energidataservice/__init__.py
+++ b/custom_components/energidataservice/__init__.py
@@ -133,7 +133,7 @@ async def _setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     update_tomorrow = async_track_time_change(
         hass,
         get_new_data,
-        hour=12,  # LOCAL time!!
+        hour=13,  # LOCAL time!!
         minute=rand_min,
         second=rand_sec,
     )


### PR DESCRIPTION
After previous fix changing from UTC to local time, the hour for daily update was kept on 12, should be 13. Effect was that daily update was done at 12xx instead of after 1300 hours. 