### PR TITLE
Update NOE ChargeTypeCode in chargeowners.py

### DIFF
--- a/custom_components/energidataservice/tariffs/energidataservice/chargeowners.py
+++ b/custom_components/energidataservice/tariffs/energidataservice/chargeowners.py
@@ -94,7 +94,7 @@ CHARGEOWNERS = {
     "Nordvestjysk Elforsyning (NOE Net)": {
         "gln": "5790000395620",
         "company": "NOE Net A/S",
-        "type": ["Net C"],
+        "type": ["30030"],
         "chargetype": ["D03"],
     },
     "Ikast El Net": {


### PR DESCRIPTION
NOE Net ChargeTypeCode has changed from "Net C" to "30030" in the datahub.