### PR TITLE
Ikast El Net - Changed chargetype

### DIFF
--- a/custom_components/energidataservice/tariffs/energidataservice/chargeowners.py
+++ b/custom_components/energidataservice/tariffs/energidataservice/chargeowners.py
@@ -100,7 +100,7 @@ CHARGEOWNERS = {
     "Ikast El Net": {
         "gln": "5790000682102",
         "company": "Ikast El Net A/S",
-        "type": ["IEV-NT-11"],
+        "type": ["IEV-NT-01"],
         "chargetype": ["D03"],
     },
     "FLOW Elnet": {


### PR DESCRIPTION
Changed chargetype to Nettarif C time (Tarif, hvor aftagepunktet typisk er i 0,4 kV-nettet med en timeaflæst måler)