### PR TITLE
Retry api update on non-200 return code

### DIFF
--- a/custom_components/energidataservice/api.py
+++ b/custom_components/energidataservice/api.py
@@ -127,7 +127,6 @@ class APIConnector:
 
                 if api.status != 200:
                     retry_update(self)
-                    break
                 
                 try:
                     await api.async_get_co2emissions()
@@ -174,7 +173,6 @@ class APIConnector:
 
                 if api.status != 200:
                     retry_update(self)
-                    break
 
                 if api.today and not self.today:
                     self.today = api.today

--- a/custom_components/energidataservice/api.py
+++ b/custom_components/energidataservice/api.py
@@ -126,7 +126,7 @@ class APIConnector:
                 await api.async_get_spotprices()
 
                 if api.status != 200:
-                    retry_update(self)
+                    retry_update(self, self.updateco2)
                 
                 try:
                     await api.async_get_co2emissions()
@@ -325,12 +325,14 @@ class APIConnector:
         return self._entry_id
 
 
-def retry_update(self) -> None:
+def retry_update(self, update_function=None) -> None:
     """Retry update on error."""
     self.retry_count += 1
     self.next_retry_delay = RETRY_MINUTES * self.retry_count
     if self.next_retry_delay > MAX_RETRY_MINUTES:
         self.next_retry_delay = MAX_RETRY_MINUTES
+    if update_function is None:
+        update_function = self.update
 
     _LOGGER.warning(
         "Couldn't get data from Energi Data Service, retrying in %s minutes.",
@@ -347,5 +349,5 @@ def retry_update(self) -> None:
     async_call_later(
         self.hass,
         timedelta(minutes=self.next_retry_delay),
-        partial(self.update),
+        partial(update_function),
     )

--- a/custom_components/energidataservice/api.py
+++ b/custom_components/energidataservice/api.py
@@ -124,6 +124,11 @@ class APIConnector:
                 )
                 self.connector_currency = module.DEFAULT_CURRENCY
                 await api.async_get_spotprices()
+
+                if api.status != 200:
+                    retry_update(self)
+                    break
+                
                 try:
                     await api.async_get_co2emissions()
                     if api.co2data:
@@ -166,6 +171,10 @@ class APIConnector:
                 )
                 self.connector_currency = module.DEFAULT_CURRENCY
                 await api.async_get_spotprices()
+
+                if api.status != 200:
+                    retry_update(self)
+                    break
 
                 if api.today and not self.today:
                     self.today = api.today

--- a/custom_components/energidataservice/connectors/fixedprice/__init__.py
+++ b/custom_components/energidataservice/connectors/fixedprice/__init__.py
@@ -58,6 +58,7 @@ class Connector:
         self.tz = tz  # pylint: disable=invalid-name
         self.regionhandler = regionhandler
         self.value = self.config.options.get(CONF_FIXED_PRICE_VALUE)
+        self.status = 200
 
     async def async_get_spotprices(self) -> None:
         """Return the fixed price set in the configuration flow."""

--- a/custom_components/energidataservice/connectors/nordpool/__init__.py
+++ b/custom_components/energidataservice/connectors/nordpool/__init__.py
@@ -53,6 +53,7 @@ class Connector:
         self.client = client
         self._result = {}
         self._tz = tz
+        self.status = 200
 
     async def async_get_spotprices(self) -> None:
         """Fetch latest spotprices, excl. VAT and tariff."""


### PR DESCRIPTION
This should fix https://github.com/MTrab/energidataservice/issues/542 and maybe https://github.com/MTrab/energidataservice/issues/526 ?

I've tested it on my local Pi HA instance by changing the API url to http, and then spoofing dns in my router to have any `GET` request to `api.energidataservice.dk` return 500. Then, after the logs show it's gotten an E500 response, removed the DNS entry in my router (which at a 10s TTL) and waiting for the API retry 

Right after boot we see the E500 associated log messages as expected
![Log messages with E500](https://github.com/user-attachments/assets/3173f73f-c76a-405a-a40c-61c88d5c5258)

Then 5min later, on the retry, the integration successfully gets the Electricity costs, but because spot prices and CO2 data are separate I guess the other, CO2 data in this case, doesn't retry after 5 minutes, but 10. IT does eventually return tho.

I did notice in the logs that https://github.com/MTrab/energidataservice/blob/master/custom_components/energidataservice/tariffs/energidataservice/__init__.py#L209 also gets hit by the E500, but this seems to be on a retry decorator, so should also be okay? Although on a sufficiently long API outage, it may run out of retries? 