### PR TITLE
Revert "Do not verify API SSL"

### DIFF
--- a/custom_components/energidataservice/api.py
+++ b/custom_components/energidataservice/api.py
@@ -82,7 +82,7 @@ class APIConnector:
         self.next_retry_delay = RETRY_MINUTES
         self.retry_count = 0
 
-        self._client = async_get_clientsession(hass, False)
+        self._client = async_get_clientsession(hass)
         self._region = RegionHandler(
             (entry.options.get(CONF_AREA) or entry.data.get(CONF_AREA)) or "FIXED"
         )


### PR DESCRIPTION
This reverts commit 8a131e24540ea285af34fc433334af1e5d98ca3c, since the api endpoint has been fixed.