### PR TITLE
Updated sensor.py `state_class`

### DIFF
--- a/custom_components/energidataservice/sensor.py
+++ b/custom_components/energidataservice/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
+    SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_EMAIL, CONF_NAME
@@ -138,7 +139,7 @@ def _setup(hass, config: ConfigEntry, add_devices):
         device_class=SensorDeviceClass.MONETARY,
         icon="mdi:flash",
         name=config.data.get(CONF_NAME),
-        state_class=None,
+        state_class=SensorStateClass.MEASUREMENT,
     )
     sens = EnergidataserviceSensor(config, hass, region, this_sensor)
     add_devices([sens])


### PR DESCRIPTION
Enable [long-term statistics](https://developers.home-assistant.io/docs/core/entity/sensor/?_highlight=state_class#long-term-statistics) as requested by [FR] #586. 

Changed sensor `state_class` from `None` to `SensorStateClass.MEASUREMENT`.