### PR TITLE
Update charge type for Flow Elnet

### DIFF
--- a/custom_components/energidataservice/tariffs/energidataservice/chargeowners.py
+++ b/custom_components/energidataservice/tariffs/energidataservice/chargeowners.py
@@ -106,7 +106,7 @@ CHARGEOWNERS = {
     "FLOW Elnet": {
         "gln": "5790000392551",
         "company": "FLOW Elnet A/S",
-        "type": ["FE2 NT-01"],
+        "type": ["FE1 NT-01"],
         "chargetype": ["D03"],
     },
     "Elinord": {


### PR DESCRIPTION
Flow Elnet changed the chargetypecode at the start of 2025


![image](https://github.com/user-attachments/assets/20b05341-c82b-407f-84fa-173c5311252f)
