### PR TITLE
Change tariff type from '50001' to 'C-Tarif'

### DIFF
--- a/custom_components/energidataservice/tariffs/energidataservice/chargeowners.py
+++ b/custom_components/energidataservice/tariffs/energidataservice/chargeowners.py
@@ -118,7 +118,7 @@ CHARGEOWNERS = {
     "Hammel Elforsyning Net": {
         "gln": "5790001090166",
         "company": "Hammel Elforsyning Net A/S",
-        "type": ["50001"],
+        "type": ["C-Tarif"],
         "chargetype": ["D03"],
     },
     "El-net Kongerslev": {


### PR DESCRIPTION
On 2023-05-01 C-Tarif started showing up.
Validated prices towards https://hammelelforsyning.dk/hl/informationer/priser/privat.aspx