### PR TITLE
Engage tariff retry on empty dataset and fix the retry callback signature

### DIFF
--- a/custom_components/energidataservice/api.py
+++ b/custom_components/energidataservice/api.py
@@ -357,7 +357,7 @@ class APIConnector:
                     or not self.tariff_data["tariffs"]
                     or not self.tariff_data["additional_tariffs"]
                 ):
-                    if self.tariff_data["status"] in [400, 403, 411]:
+                    if self.tariff_data["status"] in [400, 411]:
                         _LOGGER.warning(
                             "Tariff endpoint returned %s, skipping retry for now",
                             self.tariff_data["status"],

--- a/custom_components/energidataservice/api.py
+++ b/custom_components/energidataservice/api.py
@@ -324,7 +324,7 @@ class APIConnector:
 
                 self.api_predictions = self.predictions
 
-    async def async_get_tariffs(self, request_module=None) -> None:
+    async def async_get_tariffs(self, dt=None, request_module=None) -> None:  # type: ignore pylint: disable=unused-argument,invalid-name
         """Get tariff data."""
 
         if self.tariff:
@@ -352,7 +352,11 @@ class APIConnector:
                         "status": 503,
                     }
 
-                if self.tariff_data["status"] != 200:
+                if (
+                    self.tariff_data["status"] != 200
+                    or not self.tariff_data["tariffs"]
+                    or not self.tariff_data["additional_tariffs"]
+                ):
                     if self.tariff_data["status"] in [400, 403, 411]:
                         _LOGGER.warning(
                             "Tariff endpoint returned %s, skipping retry for now",


### PR DESCRIPTION
Fixes #979

Two small changes in `api.py` so a failed tariff fetch actually recovers via the existing `retry_update` machinery (5→60 min backoff):

**1. Treat an empty tariff dataset as a failure.**
A transient empty `200` from DatahubPricelist previously looked like success (`status == 200`), so no retry was armed — and `clear_retry` was even called — leaving all-in prices without elafgift, the system/transmission tariffs and the chargeowner tariff until the next 13:00 `get_new_data` run. The failure check now also engages when `tariffs` or `additional_tariffs` come back empty. The `400/403/411 → skip retry` behaviour is unchanged.

**2. Fix the scheduled retry callback signature.**
`retry_update` schedules `async_call_later(..., partial(update_function, request_module=module))`, and `async_call_later` invokes the callback with the fired time as a positional argument. `async_get_tariffs` was missing the `dt` parameter that `update`/`updateco2` have, so whenever a tariff retry *was* armed (429, or 5xx after the `@retry` decorator gives up) it died on first fire:

```txt
TypeError: APIConnector.async_get_tariffs() got multiple values for argument 'request_module'
```

The signature now matches its siblings.

With both changes, a transient empty response self-heals on the first 5-minute retry, while a persistently empty dataset (e.g. a stale chargeowner mapping as in #925/#835) degrades to one bounded probe per hour with a visible warning instead of silently wrong prices.

Verified with `python -m py_compile`, `black --check`, and a simulation of the `partial`/`async_call_later` invocation plus the failure-condition cases (healthy 200, empty 200, partial gaps, 429, 400, 503). Full incident analysis in #979 (v1.6.19, Radius/DK2, HA core 2026.7.2).


---

**Update 2026-08-05 (bc96f3f):** following the report in #979 of the `filter=`-blocking WAF event (HTTP 403 to any filtered query for ~7 hours) — independently confirmed on a second Radius C / DK2 install: tariffs wiped at the 13:1x daily fetch, prices short by the exact tariff stack until 20:00, and config-entry reloads unable to bridge it since every re-fetch just re-403s — this PR now also moves `403` out of the skip list, arming the same bounded 5→60 min retry. `400`/`411` keep the current skip behaviour. A persistent 403 then degrades to one probe per hour with a visible warning, instead of a silent day-scale outage with no recovery path.
