### PR TITLE
Prevent raw price spikes during concurrent sensor updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ notes.txt
 # Home Assistant configuration
 config/*
 !config/configuration.yaml
+.devcontainer-lock.json

--- a/custom_components/energidataservice/sensor.py
+++ b/custom_components/energidataservice/sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections import namedtuple
 from datetime import datetime, timedelta
@@ -382,6 +383,14 @@ class EnergidataserviceSensor(SensorEntity):
         self._friendly_name = config.options.get(CONF_NAME) or config.data.get(
             CONF_NAME
         )
+        self._validation_lock = asyncio.Lock()
+        self._today_source = None
+        self._tomorrow_source = None
+        self._predictions_source = None
+        self._tariff_data_source = None
+        self._tariff_connector_source = None
+        self._connector_currency_source = None
+        self._predictions_currency_source = None
 
         if config.options.get(CONF_VAT) is True:
             self._vat = region.vat
@@ -443,96 +452,139 @@ class EnergidataserviceSensor(SensorEntity):
 
     async def validate_data(self) -> None:
         """Validate sensor data."""
+        async with self._validation_lock:
+            await self._validate_data()
+
+    async def _validate_data(self) -> None:
+        """Validate and publish a consistent sensor data snapshot."""
         _LOGGER.debug("Validating sensor %s", self.name)
 
         # Do we have valid data for today? If not, try fetching new dataset
-        if not self._api.today:
+        if not self._api.api_today:
             _LOGGER.debug("No sensor data found - calling update")
             await self._api.update()
-            if self._api.today is not None and not self._api.today_calculated:
-                _LOGGER.debug("API currency: %s", self._api.connector_currency)
-                _LOGGER.debug("SELF currency: %s", self._currency)
-                await self._hass.async_add_executor_job(
-                    self._format_list,
-                    self._api.today,
-                    False,
-                    False,
-                    self._api.connector_currency or self._currency,
-                )
-
-        # Do we have valid data for tomorrow? If we do, calculate prices in local currency
-        # If not, set attributes to None
-        if self.tomorrow_valid:
-            if not self._api.tomorrow_calculated:
-                await self._hass.async_add_executor_job(
-                    self._format_list,
-                    self._api.tomorrow,
-                    True,
-                    False,
-                    self._api.connector_currency or self._currency,
-                )
-            self._tomorrow_raw = self._add_raw(
-                self._api.tomorrow, self._attr_suggested_display_precision
-            )
-        else:
-            self._api.tomorrow = None
-            self._tomorrow_raw = None
-            self._api.tomorrow_calculated = False
-
-        # Check if the data have been reset to API values rather than the calculated values
-        if self._api.today == self._api.api_today and not isinstance(
-            self._api.today, type(None)
-        ):
-            self._api.today_calculated = False
-
-        if self._api.tomorrow == self._api.api_tomorrow and not isinstance(
-            self._api.tomorrow, type(None)
-        ):
-            self._api.tomorrow_calculated = False
-
-        if self._api.predictions == self._api.api_predictions and not isinstance(
-            self._api.predictions, type(None)
-        ):
-            self._api.predictions_calculated = False
-
-        # If we haven't already calculated todays prices in local currency, do so now
-        if not self._api.today_calculated and not isinstance(
-            self._api.today, type(None)
-        ):
-            await self._hass.async_add_executor_job(
-                self._format_list,
-                self._api.today,
-                False,
-                False,
-                self._api.connector_currency or self._currency,
-            )
 
         # If predictions is enabled but no data exists, fetch dataset
-        if self._api.forecast and isinstance(self._api.predictions, type(None)):
+        if self._api.forecast and self._api.api_predictions is None:
             await self._api.update_carnot()
 
-        # If predictions is enabled but not calculated, do so now
-        if not self._api.predictions_calculated and not isinstance(
-            self._api.predictions, type(None)
-        ):
-            await self._hass.async_add_executor_job(
-                self._format_list,
-                self._api.predictions,
-                False,
-                True,
-                self._api.predictions_currency or self._currency,
+        # Build calculated lists from one consistent set of raw API data. If an API
+        # refresh replaces a source while calculation runs in the executor, retry
+        # once and otherwise retain the previously published state.
+        for attempt in range(2):
+            today_source = self._api.api_today
+            tomorrow_source = self._api.api_tomorrow if self.tomorrow_valid else None
+            predictions_source = (
+                self._api.api_predictions if self._api.forecast else None
             )
-        else:
-            _LOGGER.debug(
-                "Predictions: %s (%s)",
-                self._api.predictions,
-                type(self._api.predictions),
+            tariff_data_source = self._api.tariff_data
+            tariff_connector_source = self._api.tariff_connector
+            connector_currency = self._api.connector_currency or self._currency
+            predictions_currency = self._api.predictions_currency or self._currency
+
+            today = self._api.today
+            if today_source is not None and (
+                not self._api.today_calculated
+                or self._today_source is not today_source
+                or self._tariff_data_source is not tariff_data_source
+                or self._tariff_connector_source is not tariff_connector_source
+                or self._connector_currency_source != connector_currency
+            ):
+                today = await self._hass.async_add_executor_job(
+                    self._format_list,
+                    today_source,
+                    False,
+                    False,
+                    connector_currency,
+                )
+
+            tomorrow = self._api.tomorrow
+            if tomorrow_source is not None and (
+                not self._api.tomorrow_calculated
+                or self._tomorrow_source is not tomorrow_source
+                or self._tariff_data_source is not tariff_data_source
+                or self._tariff_connector_source is not tariff_connector_source
+                or self._connector_currency_source != connector_currency
+            ):
+                tomorrow = await self._hass.async_add_executor_job(
+                    self._format_list,
+                    tomorrow_source,
+                    True,
+                    False,
+                    connector_currency,
+                )
+
+            predictions = self._api.predictions
+            if predictions_source is not None and (
+                not self._api.predictions_calculated
+                or self._predictions_source is not predictions_source
+                or self._tariff_data_source is not tariff_data_source
+                or self._tariff_connector_source is not tariff_connector_source
+                or self._predictions_currency_source != predictions_currency
+            ):
+                predictions = await self._hass.async_add_executor_job(
+                    self._format_list,
+                    predictions_source,
+                    False,
+                    True,
+                    predictions_currency,
+                )
+
+            sources_unchanged = (
+                today_source is self._api.api_today
+                and tomorrow_source
+                is (self._api.api_tomorrow if self.tomorrow_valid else None)
+                and predictions_source
+                is (self._api.api_predictions if self._api.forecast else None)
+                and tariff_data_source is self._api.tariff_data
+                and tariff_connector_source is self._api.tariff_connector
+                and connector_currency
+                == (self._api.connector_currency or self._currency)
+                and predictions_currency
+                == (self._api.predictions_currency or self._currency)
             )
+            if not sources_unchanged:
+                _LOGGER.debug("Price data changed during calculation, retrying")
+                if attempt == 0:
+                    continue
+                _LOGGER.warning(
+                    "Price data kept changing during calculation; retaining the "
+                    "previous sensor state"
+                )
+                return
+
+            # Commit calculated data only after every source has been verified. No
+            # await is allowed between this point and writing the Home Assistant
+            # state, so raw and calculated data cannot be interleaved.
+            self._api.today = today if today_source is not None else None
+            self._api.today_calculated = today_source is not None
+            self._api.tomorrow = tomorrow if tomorrow_source is not None else None
+            self._api.tomorrow_calculated = tomorrow_source is not None
+            self._api.predictions = (
+                predictions if predictions_source is not None else None
+            )
+            self._api.predictions_calculated = predictions_source is not None
+
+            self._today_source = today_source
+            self._tomorrow_source = tomorrow_source
+            self._predictions_source = predictions_source
+            self._tariff_data_source = tariff_data_source
+            self._tariff_connector_source = tariff_connector_source
+            self._connector_currency_source = connector_currency
+            self._predictions_currency_source = predictions_currency
+            break
 
         # Update attributes
         if self._api.today:
             self._today_raw = self._add_raw(
                 self._api.today, self._attr_suggested_display_precision
+            )
+            self._tomorrow_raw = (
+                self._add_raw(
+                    self._api.tomorrow, self._attr_suggested_display_precision
+                )
+                if self._api.tomorrow
+                else None
             )
 
             self._today_min = self._get_specific(
@@ -604,16 +656,9 @@ class EnergidataserviceSensor(SensorEntity):
 
     def _get_current_price(self) -> None:
         """Get price for current hour."""
-        current_state_time = datetime.fromisoformat(
-            dt_utils.now()
-            .replace(microsecond=0)
-            .replace(second=0)
-            .replace(minute=0)
-            .isoformat()
-        )
         if self._api.today:
             for dataset in self._api.today:
-                if not dataset.time.hour == dt_utils.now().hour:
+                if dataset.time.hour != dt_utils.now().hour:
                     continue
 
                 if (
@@ -735,6 +780,7 @@ class EnergidataserviceSensor(SensorEntity):
 
         Returns:
             list: sorted list where today[0] is the price of hour 00.00 - 01.00.
+
         """
         return (
             [
@@ -752,6 +798,7 @@ class EnergidataserviceSensor(SensorEntity):
 
         Returns:
             list: sorted where tomorrow[0] is the price of hour 00.00 - 01.00 etc.
+
         """
         if self._api.tomorrow_valid:
             return [
@@ -952,7 +999,7 @@ class EnergidataserviceSensor(SensorEntity):
 
     def _format_list(
         self, data, tomorrow=False, predictions=False, default_currency: str = "EUR"
-    ) -> None:
+    ) -> list:
         """Format data as list with prices localized."""
         formatted_pricelist = []
 
@@ -977,16 +1024,10 @@ class EnergidataserviceSensor(SensorEntity):
 
         if tomorrow:
             _calc_for = "TOMORROW"
-            self._api.tomorrow_calculated = True
-            self._api.tomorrow = formatted_pricelist
         elif predictions:
             _calc_for = "PREDICTIONS"
-            self._api.predictions_calculated = True
-            self._api.predictions = formatted_pricelist
         else:
             _calc_for = "TODAY"
-            self._api.today_calculated = True
-            self._api.today = formatted_pricelist
 
         _LOGGER.debug(
             "Calculation for %s in %s took %s seconds",
@@ -994,6 +1035,7 @@ class EnergidataserviceSensor(SensorEntity):
             self.region.region,
             _ttf,
         )
+        return formatted_pricelist
 
     @staticmethod
     def _get_specific(datatype: str, data: list, decimals: int):

--- a/tests/test_sensor_concurrency.py
+++ b/tests/test_sensor_concurrency.py
@@ -1,0 +1,229 @@
+"""Regression tests for concurrent price sensor updates."""
+
+from __future__ import annotations
+
+import asyncio
+from types import MethodType, SimpleNamespace
+
+import pytest
+from homeassistant.util import dt as dt_utils
+
+from custom_components.energidataservice.const import CONF_RESOLUTION, INTERVAL
+from custom_components.energidataservice.sensor import EnergidataserviceSensor
+
+RAW_PRICE = 109.565
+CONVERSION_FACTOR = 7.46 / 1000
+
+
+class ControlledHass:
+    """Minimal Home Assistant executor facade with a controllable first job."""
+
+    def __init__(self) -> None:
+        """Initialize executor control events."""
+        self.first_job_started = asyncio.Event()
+        self.release_first_job = asyncio.Event()
+        self.job_count = 0
+
+    async def async_add_executor_job(self, target, *args):
+        """Run executor jobs after optionally pausing the first one."""
+        self.job_count += 1
+        if self.job_count == 1:
+            self.first_job_started.set()
+            await self.release_first_job.wait()
+        return target(*args)
+
+
+def _raw_data(price: float) -> list:
+    """Return raw data matching the current quarter."""
+    now = dt_utils.now()
+    interval_start = now.replace(
+        minute=(now.minute // 15) * 15,
+        second=0,
+        microsecond=0,
+    )
+    return [INTERVAL(price, interval_start)]
+
+
+def _sensor(hass: ControlledHass, raw_today: list) -> EnergidataserviceSensor:
+    """Create the smallest sensor instance needed for data validation."""
+    api = SimpleNamespace(
+        api_today=raw_today,
+        api_tomorrow=None,
+        api_predictions=None,
+        today=raw_today,
+        tomorrow=None,
+        predictions=None,
+        today_calculated=False,
+        tomorrow_calculated=False,
+        predictions_calculated=False,
+        forecast=False,
+        tariff_data=None,
+        tariff_connector=None,
+        connector_currency="EUR",
+        predictions_currency=None,
+        tomorrow_valid=False,
+        source="test",
+        next_data_refresh="13:30:00",
+    )
+
+    sensor = object.__new__(EnergidataserviceSensor)
+    sensor._api = api
+    sensor._hass = hass
+    sensor._validation_lock = asyncio.Lock()
+    sensor._today_source = None
+    sensor._tomorrow_source = None
+    sensor._predictions_source = None
+    sensor._tariff_data_source = None
+    sensor._tariff_connector_source = None
+    sensor._connector_currency_source = None
+    sensor._predictions_currency_source = None
+    sensor._currency = "DKK"
+    sensor._forecast = False
+    sensor._cent = False
+    sensor._vat = 0
+    sensor._price_type = "kWh"
+    sensor._area = "East of the great belt"
+    sensor.region = SimpleNamespace(region="DK2")
+    sensor._friendly_name = "Energi Data Service"
+    sensor._attr_suggested_display_precision = 3
+    sensor._attr_native_unit_of_measurement = "DKK/kWh"
+    sensor._config = SimpleNamespace(options={CONF_RESOLUTION: False}, data={})
+    sensor._today_raw = None
+    sensor._tomorrow_raw = None
+    sensor._today_min = None
+    sensor._today_max = None
+    sensor._today_remaining_min = None
+    sensor._today_remaining_max = None
+    sensor._today_mean = None
+    sensor._today_remaining_mean = None
+    sensor._tomorrow_min = None
+    sensor._tomorrow_max = None
+    sensor._tomorrow_mean = None
+    sensor._calculate = MethodType(
+        lambda self, value=None, fake_dt=None, default_currency="EUR": (
+            value * CONVERSION_FACTOR
+        ),
+        sensor,
+    )
+    return sensor
+
+
+@pytest.mark.asyncio
+async def test_concurrent_validation_never_publishes_raw_price() -> None:
+    """A raw-list reset during validation must never reach sensor state."""
+    hass = ControlledHass()
+    raw_today = _raw_data(RAW_PRICE)
+    sensor = _sensor(hass, raw_today)
+    published_values = []
+    sensor.async_write_ha_state = lambda: published_values.append(
+        sensor._attr_native_value
+    )
+
+    first_validation = asyncio.create_task(sensor.validate_data())
+    await hass.first_job_started.wait()
+
+    # Reproduce the unsafe state formerly created by the quarter-hour callback.
+    sensor._api.today = sensor._api.api_today
+    sensor._api.today_calculated = False
+    second_validation = asyncio.create_task(sensor.validate_data())
+
+    await asyncio.sleep(0)
+    assert not second_validation.done()
+
+    hass.release_first_job.set()
+    await asyncio.gather(first_validation, second_validation)
+
+    expected_price = RAW_PRICE * CONVERSION_FACTOR
+    assert hass.job_count == 1
+    assert published_values == pytest.approx([expected_price, expected_price])
+    assert RAW_PRICE not in published_values
+    assert sensor._api.today_calculated is True
+    assert sensor._api.today[0].price == pytest.approx(expected_price)
+
+
+@pytest.mark.asyncio
+async def test_source_replaced_during_calculation_is_recalculated() -> None:
+    """Only a calculation made from the newest raw snapshot may be committed."""
+    hass = ControlledHass()
+    sensor = _sensor(hass, _raw_data(RAW_PRICE))
+    published_values = []
+    sensor.async_write_ha_state = lambda: published_values.append(
+        sensor._attr_native_value
+    )
+
+    validation = asyncio.create_task(sensor.validate_data())
+    await hass.first_job_started.wait()
+
+    replacement_price = 87.25
+    replacement_data = _raw_data(replacement_price)
+    sensor._api.api_today = replacement_data
+    sensor._api.today = replacement_data
+    sensor._api.today_calculated = False
+
+    hass.release_first_job.set()
+    await validation
+
+    expected_price = replacement_price * CONVERSION_FACTOR
+    assert hass.job_count == 2
+    assert published_values == pytest.approx([expected_price])
+    assert RAW_PRICE not in published_values
+    assert sensor._api.today[0].price == pytest.approx(expected_price)
+
+
+def test_format_list_does_not_mutate_shared_api_data() -> None:
+    """Formatting must return calculated data without changing its source."""
+    hass = ControlledHass()
+    raw_today = _raw_data(RAW_PRICE)
+    sensor = _sensor(hass, raw_today)
+
+    formatted = sensor._format_list(raw_today, default_currency="EUR")
+
+    assert sensor._api.today is raw_today
+    assert sensor._api.today_calculated is False
+    assert formatted is not raw_today
+    assert formatted[0].price == pytest.approx(RAW_PRICE * CONVERSION_FACTOR)
+
+
+@pytest.mark.asyncio
+async def test_replaced_tariffs_invalidate_calculated_prices() -> None:
+    """A tariff refresh must still trigger price recalculation."""
+    hass = ControlledHass()
+    hass.release_first_job.set()
+    sensor = _sensor(hass, _raw_data(RAW_PRICE))
+    sensor.async_write_ha_state = lambda: None
+
+    await sensor.validate_data()
+    sensor._api.tariff_data = {
+        "additional_tariffs": {},
+        "status": 200,
+        "tariffs": {},
+    }
+    await sensor.validate_data()
+
+    assert hass.job_count == 2
+
+
+@pytest.mark.asyncio
+async def test_tomorrow_and_forecast_are_calculated_from_raw_sources() -> None:
+    """Tomorrow and forecast behavior must be preserved by snapshot validation."""
+    hass = ControlledHass()
+    hass.release_first_job.set()
+    sensor = _sensor(hass, _raw_data(RAW_PRICE))
+    tomorrow_source = _raw_data(82.4)
+    predictions_source = _raw_data(76.3)
+    sensor._api.api_tomorrow = tomorrow_source
+    sensor._api.tomorrow = tomorrow_source
+    sensor._api.tomorrow_valid = True
+    sensor._api.api_predictions = predictions_source
+    sensor._api.predictions = predictions_source
+    sensor._api.forecast = True
+    sensor._forecast = True
+    sensor.async_write_ha_state = lambda: None
+
+    await sensor.validate_data()
+
+    assert hass.job_count == 3
+    assert sensor._api.tomorrow_calculated is True
+    assert sensor._api.predictions_calculated is True
+    assert sensor._api.tomorrow[0].price == pytest.approx(82.4 * CONVERSION_FACTOR)
+    assert sensor._api.predictions[0].price == pytest.approx(76.3 * CONVERSION_FACTOR)


### PR DESCRIPTION
Concurrent price refreshes could publish an unconverted connector price as the sensor state. Serialize sensor validation, calculate lists without mutating shared API data, and verify raw sources, tariffs, and currencies before committing calculated values and publishing state. Retry once if sources change during calculation, retaining the previous state if they keep changing.

Add five regression tests covering overlapping validations, source replacement during calculation, side-effect-free formatting, tariff invalidation, and tomorrow/forecast calculations. Also ignore the local devcontainer lock file.

Validation: Python 3.14.7 with the pinned Home Assistant and pytest versions; all five tests pass. `ruff format`, `ruff check --fix`, `ruff check`, and `git diff --check` pass for the changed files. The repository has no `.pre-commit-config.yaml`, so Ruff uses the existing `.ruff.toml`.

Limitations: tests use a controlled executor facade and mocked conversion; no live Home Assistant or external API validation was performed. Existing historical statistics are not repaired by this change. No configuration changes are required.

Semver label: `patch` (confirmed by maintainer).

Fixes #995

