### PR TITLE
Fix formatting workflow with Ruff and Python 3.13

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -8,32 +8,32 @@ on:
 
 jobs:
   format:
-    name: Format with black and isort
+    name: Format with Ruff
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Set up Python 3.11
+      - name: Set up Python 3.13
         uses: actions/setup-python@v7.0.0
         with:
-          python-version: 3.11
+          python-version: "3.13"
       - name: Cache
         uses: actions/cache@v6.1.0
         with:
           path: ~/.cache/pip
-          key: pip-format
+          key: pip-format-ruff-py313-${{ hashFiles('requirements.txt') }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          python -m pip install --upgrade black isort
+          python -m pip install "$(sed -n '/^ruff==/p' requirements.txt)"
       - name: Pull again
         run: git pull || true
       - name: Run formatting
         run: |
-          python -m isort -v --multi-line 3 --trailing-comma -l 88 --recursive .
-          python -m black -v .
+          python -m ruff check --select I --fix .
+          python -m ruff format .
       - name: Commit files
         run: |
           if [ $(git diff HEAD | wc -l) -gt 30 ]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,6 @@
 # The contents of this file is based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 
-target-version = "py311"
+target-version = "py313"
 
 select = [
     "B007", # Loop control variable {name} not used within loop body


### PR DESCRIPTION
The post-merge formatting job fails because isort rejects `--recursive`. Replace Black/isort with Ruff import sorting and formatting, using the Ruff version pinned in `requirements.txt`.

Run the formatting job on Python 3.13, set Ruff's target to `py313`, and key the pip cache by Python version and requirements.

Validation: the workflow's Ruff commands passed in a temporary repository copy using Ruff 0.16.0. Import checks and format checks passed after formatting all 31 Python files. `git diff --check` passed. No integration behavior changed.

Known limitations: full repository lint reports 16 existing issues outside this change; four files need formatting under Ruff. Local validation ran on Python 3.14.7; the workflow specifies Python 3.13. The formatting workflow runs on master pushes or manual dispatch, so it will not execute automatically on this PR.

Configuration changes: CI Python version and Ruff target are now 3.13. No user configuration changes are required.
