### PR TITLE
Expose detailed electricity price breakdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Here you have a list of the available attributes, along with a brief description
 Attribute name | Description | Adittional info
 ---|---|---
 current_price | Price for the current hour, same as the sensor state|
+current_price_breakdown | Spot price and every cost component used to calculate the current price | Uses the same structure as an entry in `raw_today`
 unit | The unit used for price calculations | One of MWh, kWh or Wh
 currency | The prices are displayed in this currency
 region | The region that was selected | This is the "human readable" version of the region
@@ -104,8 +105,8 @@ tomorrow_valid | True if there was received prices for tomorrow | Prices will be
 next_data_update | The API will be pulled at this time | If no data for today or tomorrow was found, the integration will keep trying at random intervals
 today | Array containing ONLY the prices for today |
 tomorrow | Array containing ONLY the prices for tomorrow | Will be empty if tomorro_valid is false
-raw_today | 24 objects containing a timestamp and a price, representating each hour in the day |
-raw_tomorrow | 24 objects containing a timestamp and a price, representating each hour in the day | Will be empty if tomorrow_valid is false
+raw_today | Timestamped total price and its spot price, tariff, additional cost and VAT components for every interval today | Components are shown before VAT; `price` is the total including VAT
+raw_tomorrow | Timestamped total price and its components for every interval tomorrow | Will be empty if tomorrow_valid is false
 today_min | Lowest price of today, as an object containing the hour and the price |
 today_max | Highest price of today, as an object containing the hour and the price |
 today_mean | Mean price of today, as an object containing the hour and the price |

--- a/custom_components/energidataservice/const.py
+++ b/custom_components/energidataservice/const.py
@@ -14,6 +14,7 @@ https://github.com/mtrab/energidataservice/issues
 """
 
 ATTR_CURRENT_PRICE = "current_price"
+ATTR_CURRENT_PRICE_BREAKDOWN = "current_price_breakdown"
 ATTR_UNIT = "unit"
 ATTR_CURRENCY = "currency"
 ATTR_REGION = "region"

--- a/custom_components/energidataservice/sensor.py
+++ b/custom_components/energidataservice/sensor.py
@@ -30,6 +30,7 @@ from .const import (
     ATTR_ATTRIBUTION,
     ATTR_CURRENCY,
     ATTR_CURRENT_PRICE,
+    ATTR_CURRENT_PRICE_BREAKDOWN,
     ATTR_FORECAST,
     ATTR_NET_OPERATOR,
     ATTR_NEXT_DATA_UPDATE,
@@ -391,6 +392,9 @@ class EnergidataserviceSensor(SensorEntity):
         self._tariff_connector_source = None
         self._connector_currency_source = None
         self._predictions_currency_source = None
+        self._price_breakdown_today = None
+        self._price_breakdown_tomorrow = None
+        self._current_price_breakdown = None
 
         if config.options.get(CONF_VAT) is True:
             self._vat = region.vat
@@ -485,34 +489,43 @@ class EnergidataserviceSensor(SensorEntity):
             today = self._api.today
             if today_source is not None and (
                 not self._api.today_calculated
+                or self._price_breakdown_today is None
                 or self._today_source is not today_source
                 or self._tariff_data_source is not tariff_data_source
                 or self._tariff_connector_source is not tariff_connector_source
                 or self._connector_currency_source != connector_currency
             ):
-                today = await self._hass.async_add_executor_job(
-                    self._format_list,
+                today, price_breakdown_today = await self._hass.async_add_executor_job(
+                    self._format_list_with_breakdown,
                     today_source,
                     False,
                     False,
                     connector_currency,
                 )
+            else:
+                price_breakdown_today = self._price_breakdown_today
 
             tomorrow = self._api.tomorrow
             if tomorrow_source is not None and (
                 not self._api.tomorrow_calculated
+                or self._price_breakdown_tomorrow is None
                 or self._tomorrow_source is not tomorrow_source
                 or self._tariff_data_source is not tariff_data_source
                 or self._tariff_connector_source is not tariff_connector_source
                 or self._connector_currency_source != connector_currency
             ):
-                tomorrow = await self._hass.async_add_executor_job(
-                    self._format_list,
+                (
+                    tomorrow,
+                    price_breakdown_tomorrow,
+                ) = await self._hass.async_add_executor_job(
+                    self._format_list_with_breakdown,
                     tomorrow_source,
                     True,
                     False,
                     connector_currency,
                 )
+            else:
+                price_breakdown_tomorrow = self._price_breakdown_tomorrow
 
             predictions = self._api.predictions
             if predictions_source is not None and (
@@ -564,6 +577,12 @@ class EnergidataserviceSensor(SensorEntity):
                 predictions if predictions_source is not None else None
             )
             self._api.predictions_calculated = predictions_source is not None
+            self._price_breakdown_today = (
+                price_breakdown_today if today_source is not None else None
+            )
+            self._price_breakdown_tomorrow = (
+                price_breakdown_tomorrow if tomorrow_source is not None else None
+            )
 
             self._today_source = today_source
             self._tomorrow_source = tomorrow_source
@@ -576,16 +595,8 @@ class EnergidataserviceSensor(SensorEntity):
 
         # Update attributes
         if self._api.today:
-            self._today_raw = self._add_raw(
-                self._api.today, self._attr_suggested_display_precision
-            )
-            self._tomorrow_raw = (
-                self._add_raw(
-                    self._api.tomorrow, self._attr_suggested_display_precision
-                )
-                if self._api.tomorrow
-                else None
-            )
+            self._today_raw = self._price_breakdown_today
+            self._tomorrow_raw = self._price_breakdown_tomorrow
 
             self._today_min = self._get_specific(
                 "min", self._api.today, self._attr_suggested_display_precision
@@ -657,7 +668,8 @@ class EnergidataserviceSensor(SensorEntity):
     def _get_current_price(self) -> None:
         """Get price for current hour."""
         if self._api.today:
-            for dataset in self._api.today:
+            self._current_price_breakdown = None
+            for index, dataset in enumerate(self._api.today):
                 if dataset.time.hour != dt_utils.now().hour:
                     continue
 
@@ -673,6 +685,7 @@ class EnergidataserviceSensor(SensorEntity):
                     )
                 ):
                     self._attr_native_value = dataset.price
+                    self._current_price_breakdown = self._price_breakdown_today[index]
                     _LOGGER.debug(
                         "Current price updated to %f for %s",
                         self._attr_native_value,
@@ -682,6 +695,7 @@ class EnergidataserviceSensor(SensorEntity):
 
             self._attr_extra_state_attributes = {
                 ATTR_CURRENT_PRICE: self.state,
+                ATTR_CURRENT_PRICE_BREAKDOWN: self._current_price_breakdown,
                 ATTR_UNIT: self.unit,
                 ATTR_CURRENCY: self._currency,
                 ATTR_REGION: self._area,
@@ -897,6 +911,15 @@ class EnergidataserviceSensor(SensorEntity):
         default_currency: str = "EUR",
     ) -> float:
         """Do price calculations."""
+        return self._calculate_breakdown(value, fake_dt, default_currency)["total"]
+
+    def _calculate_breakdown(
+        self,
+        value=None,
+        fake_dt=datetime,
+        default_currency: str = "EUR",
+    ) -> dict:
+        """Calculate a price and retain every component used in its total."""
         if value is None:
             value = self._attr_native_value
 
@@ -915,6 +938,7 @@ class EnergidataserviceSensor(SensorEntity):
         tariff_value = 0
         owner_tariff = 0
         elafgift = 0
+        system_tariffs = {}
         if (
             self._api.tariff_data is not None
             and fake_dt is not None
@@ -930,9 +954,11 @@ class EnergidataserviceSensor(SensorEntity):
 
                 if system_tariff:
                     for tariff, additional_tariff in system_tariff.items():
-                        tariff_value += float(additional_tariff)
+                        component_value = float(additional_tariff)
+                        system_tariffs[tariff] = component_value
+                        tariff_value += component_value
                         if tariff == "elafgift":
-                            elafgift = float(additional_tariff)
+                            elafgift = component_value
 
                 owner_tariff = float(
                     chargeowner_tariff[str(fake_dt.hour)] if chargeowner_tariff else 0
@@ -952,12 +978,12 @@ class EnergidataserviceSensor(SensorEntity):
                 "Error adding tariffs for %s, empty tariff dataset was found!", fake_dt
             )
 
-        price = value / UNIT_TO_MULTIPLIER[self._price_type]
+        spot_price = value / UNIT_TO_MULTIPLIER[self._price_type]
 
         template_value = self._cost_template.async_render(
             now=faker(),
             current_tariff=tariff_value,
-            current_price=price,
+            current_price=spot_price,
             el_afgift=elafgift,
             chargeowner_tariff=owner_tariff,
         )
@@ -977,11 +1003,11 @@ class EnergidataserviceSensor(SensorEntity):
             template_value = 0
 
         try:
-            price += template_value + tariff_value
+            subtotal = spot_price + template_value + tariff_value
         except Exception:
             _LOGGER.debug(
                 "Price %s template value %s type %s dt %s tariff_value %s ",
-                price,
+                spot_price,
                 template_value,
                 type(template_value),
                 fake_dt,
@@ -989,13 +1015,62 @@ class EnergidataserviceSensor(SensorEntity):
             )
             raise
 
-        # Add vat if selected
-        price = price * (float(1 + self._vat))
+        vat = subtotal * self._vat
+        total = subtotal + vat
 
         if self._cent:
-            price = price * CENT_MULTIPLIER
+            spot_price *= CENT_MULTIPLIER
+            owner_tariff *= CENT_MULTIPLIER
+            template_value *= CENT_MULTIPLIER
+            vat *= CENT_MULTIPLIER
+            total *= CENT_MULTIPLIER
+            system_tariffs = {
+                name: price * CENT_MULTIPLIER for name, price in system_tariffs.items()
+            }
 
-        return price
+        return {
+            "spot_price": spot_price,
+            "chargeowner_tariff": owner_tariff,
+            "system_tariffs": system_tariffs,
+            "additional_cost": template_value,
+            "vat": vat,
+            "total": total,
+        }
+
+    def _format_list_with_breakdown(
+        self, data, tomorrow=False, predictions=False, default_currency: str = "EUR"
+    ) -> tuple[list, list]:
+        """Format prices and their components from the same calculations."""
+        formatted_pricelist = []
+        breakdown = []
+        interval = namedtuple("Interval", "price time")
+        decimals = self._attr_suggested_display_precision
+
+        for item in data:
+            components = self._calculate_breakdown(
+                item.price,
+                fake_dt=dt_utils.as_local(item.time),
+                default_currency=default_currency,
+            )
+            formatted_pricelist.append(interval(components["total"], item.time))
+            breakdown.append(
+                {
+                    "hour": item.time,
+                    "price": round(components["total"], decimals),
+                    "spot_price": round(components["spot_price"], decimals),
+                    "chargeowner_tariff": round(
+                        components["chargeowner_tariff"], decimals
+                    ),
+                    **{
+                        name: round(price, decimals)
+                        for name, price in components["system_tariffs"].items()
+                    },
+                    "additional_cost": round(components["additional_cost"], decimals),
+                    "vat": round(components["vat"], decimals),
+                }
+            )
+
+        return formatted_pricelist, breakdown
 
     def _format_list(
         self, data, tomorrow=False, predictions=False, default_currency: str = "EUR"

--- a/tests/test_sensor_concurrency.py
+++ b/tests/test_sensor_concurrency.py
@@ -77,6 +77,9 @@ def _sensor(hass: ControlledHass, raw_today: list) -> EnergidataserviceSensor:
     sensor._tariff_connector_source = None
     sensor._connector_currency_source = None
     sensor._predictions_currency_source = None
+    sensor._price_breakdown_today = None
+    sensor._price_breakdown_tomorrow = None
+    sensor._current_price_breakdown = None
     sensor._currency = "DKK"
     sensor._forecast = False
     sensor._cent = False
@@ -103,6 +106,17 @@ def _sensor(hass: ControlledHass, raw_today: list) -> EnergidataserviceSensor:
         lambda self, value=None, fake_dt=None, default_currency="EUR": (
             value * CONVERSION_FACTOR
         ),
+        sensor,
+    )
+    sensor._calculate_breakdown = MethodType(
+        lambda self, value=None, fake_dt=None, default_currency="EUR": {
+            "spot_price": value * CONVERSION_FACTOR,
+            "chargeowner_tariff": 0,
+            "system_tariffs": {},
+            "additional_cost": 0,
+            "vat": 0,
+            "total": value * CONVERSION_FACTOR,
+        },
         sensor,
     )
     return sensor
@@ -139,6 +153,7 @@ async def test_concurrent_validation_never_publishes_raw_price() -> None:
     assert RAW_PRICE not in published_values
     assert sensor._api.today_calculated is True
     assert sensor._api.today[0].price == pytest.approx(expected_price)
+    assert sensor._price_breakdown_today[0]["price"] == round(expected_price, 3)
 
 
 @pytest.mark.asyncio
@@ -168,6 +183,7 @@ async def test_source_replaced_during_calculation_is_recalculated() -> None:
     assert published_values == pytest.approx([expected_price])
     assert RAW_PRICE not in published_values
     assert sensor._api.today[0].price == pytest.approx(expected_price)
+    assert sensor._price_breakdown_today[0]["spot_price"] == round(expected_price, 3)
 
 
 def test_format_list_does_not_mutate_shared_api_data() -> None:
@@ -182,6 +198,59 @@ def test_format_list_does_not_mutate_shared_api_data() -> None:
     assert sensor._api.today_calculated is False
     assert formatted is not raw_today
     assert formatted[0].price == pytest.approx(RAW_PRICE * CONVERSION_FACTOR)
+
+
+def test_price_breakdown_contains_every_component() -> None:
+    """The exposed components must reproduce the calculated total."""
+    hass = ControlledHass()
+    raw_today = _raw_data(100)
+    sensor = _sensor(hass, raw_today)
+    sensor._currency = "EUR"
+    sensor._vat = 0.25
+    sensor._calculate_breakdown = MethodType(
+        EnergidataserviceSensor._calculate_breakdown, sensor
+    )
+    sensor._cost_template = SimpleNamespace(async_render=lambda **_: 0.01)
+    sensor._api.tariff_data = {
+        "additional_tariffs": {"systemtarif": 0.09, "elafgift": 0.05},
+        "status": 200,
+        "tariffs": {str(hour): 0.2 for hour in range(24)},
+    }
+    sensor._api.tariff_connector = SimpleNamespace(
+        get_dated_system_tariff=lambda _: {"systemtarif": 0.09, "elafgift": 0.05},
+        get_dated_tariff=lambda _: {str(hour): 0.2 for hour in range(24)},
+    )
+
+    prices, breakdown = sensor._format_list_with_breakdown(raw_today)
+
+    item = breakdown[0]
+    assert item == {
+        "hour": raw_today[0].time,
+        "price": 0.562,
+        "spot_price": 0.1,
+        "chargeowner_tariff": 0.2,
+        "systemtarif": 0.09,
+        "elafgift": 0.05,
+        "additional_cost": 0.01,
+        "vat": 0.113,
+    }
+    assert prices[0].price == pytest.approx(0.5625)
+
+
+def test_price_breakdown_uses_cent_for_all_components() -> None:
+    """Cent display must be applied consistently to the whole breakdown."""
+    sensor = _sensor(ControlledHass(), _raw_data(100))
+    sensor._currency = "EUR"
+    sensor._cent = True
+    sensor._calculate_breakdown = MethodType(
+        EnergidataserviceSensor._calculate_breakdown, sensor
+    )
+    sensor._cost_template = SimpleNamespace(async_render=lambda **_: 0)
+
+    components = sensor._calculate_breakdown(100)
+
+    assert components["spot_price"] == pytest.approx(10)
+    assert components["total"] == pytest.approx(10)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The total electricity price currently hides the spot price and the individual costs used to calculate it. This change extends each existing `raw_today` and `raw_tomorrow` entry with the spot price, charge-owner tariff, named system tariffs, additional template cost, and VAT while keeping `price` as the final total.

`current_price_breakdown` exposes the same structure for the active interval. All values follow the sensor's configured currency, unit, precision, and cent setting, and fixed-price configurations consistently use `spot_price` as the base component.

## Attribute examples

The current interval is exposed as one object:

```yaml
current_price_breakdown:
  hour: "2026-09-05T00:00:00+02:00"
  price: 0.803
  spot_price: 0.383
  chargeowner_tariff: 0.049
  transmissions_nettarif: 0.043
  systemtarif: 0.072
  elafgift: 0.008
  additional_cost: 0.087
  vat: 0.161
```

The existing raw attributes retain `hour` and the final `price` and add the same components to every interval:

```yaml
raw_today:
  - hour: "2026-09-05T00:00:00+02:00"
    price: 0.803
    spot_price: 0.383
    chargeowner_tariff: 0.049
    transmissions_nettarif: 0.043
    systemtarif: 0.072
    elafgift: 0.008
    additional_cost: 0.087
    vat: 0.161
  - hour: "2026-09-05T01:00:00+02:00"
    price: 0.781
    spot_price: 0.365
    chargeowner_tariff: 0.049
    transmissions_nettarif: 0.043
    systemtarif: 0.072
    elafgift: 0.008
    additional_cost: 0.088
    vat: 0.156
```

`raw_tomorrow` uses the same structure when tomorrow's prices are available and remains `null` otherwise. Component values are before VAT, `vat` is the VAT amount for the complete subtotal, and `price` is the final price including VAT.

## Test strategy

- `ruff format --check custom_components/energidataservice/const.py custom_components/energidataservice/sensor.py tests/test_sensor_concurrency.py`
- `ruff check custom_components/energidataservice/const.py custom_components/energidataservice/sensor.py tests/test_sensor_concurrency.py`
- `PYTHONPATH=. pytest -q` (7 passed)

Tests cover component calculations, VAT, cent conversion, tariff invalidation, missing tomorrow data, and concurrent source replacement.

## Known limitations

User-defined template costs are exposed as one `additional_cost` value because the template produces a single result.

## Configuration changes

None.

## Proposed semver

`minor` (pending explicit maintainer confirmation before the label is applied).

Fixes #938
